### PR TITLE
Add marker clustering to Spotswood historic map

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,12 +15,15 @@
     <script src="https://code.jquery.com/jquery-1.12.4.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"></script>
+    <script src="https://unpkg.com/leaflet.markercluster@1.5.3/dist/leaflet.markercluster.js"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css"/>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css"/>
     <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap.min.css"/>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css"/>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.css"/>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/python-visualization/folium/folium/templates/leaflet.awesome.rotate.min.css"/>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.css"/>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.Default.css"/>
     
             <meta name="viewport" content="width=device-width,
                 initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
@@ -81,8 +84,8 @@
             ).addTo(map_5a86a823c94abc29f7af77eb55dccd12);
         
     
-            var feature_group_50490d869b542fd04c94566f9ceacace = L.featureGroup(
-                {}
+            var feature_group_50490d869b542fd04c94566f9ceacace = L.markerClusterGroup(
+                {"showCoverageOnHover": false, "spiderfyOnMaxZoom": true, "disableClusteringAtZoom": 17}
             ).addTo(map_5a86a823c94abc29f7af77eb55dccd12);
         
     
@@ -113,8 +116,8 @@
         
     
     
-            var feature_group_77be198ec97b345001b19fd70f6f2f27 = L.featureGroup(
-                {}
+            var feature_group_77be198ec97b345001b19fd70f6f2f27 = L.markerClusterGroup(
+                {"showCoverageOnHover": false, "spiderfyOnMaxZoom": true, "disableClusteringAtZoom": 17}
             ).addTo(map_5a86a823c94abc29f7af77eb55dccd12);
         
     
@@ -226,8 +229,8 @@
         
     
     
-            var feature_group_18801fbfbd48cd4dbdc915ece23a77f7 = L.featureGroup(
-                {}
+            var feature_group_18801fbfbd48cd4dbdc915ece23a77f7 = L.markerClusterGroup(
+                {"showCoverageOnHover": false, "spiderfyOnMaxZoom": true, "disableClusteringAtZoom": 17}
             ).addTo(map_5a86a823c94abc29f7af77eb55dccd12);
         
     
@@ -555,8 +558,8 @@
         
     
     
-            var feature_group_832d613c6612c1b69f848bf3d0d75930 = L.featureGroup(
-                {}
+            var feature_group_832d613c6612c1b69f848bf3d0d75930 = L.markerClusterGroup(
+                {"showCoverageOnHover": false, "spiderfyOnMaxZoom": true, "disableClusteringAtZoom": 17}
             ).addTo(map_5a86a823c94abc29f7af77eb55dccd12);
         
     
@@ -641,8 +644,8 @@
         
     
     
-            var feature_group_f80678cead04fc3db2a44c44487cbe8f = L.featureGroup(
-                {}
+            var feature_group_f80678cead04fc3db2a44c44487cbe8f = L.markerClusterGroup(
+                {"showCoverageOnHover": false, "spiderfyOnMaxZoom": true, "disableClusteringAtZoom": 17}
             ).addTo(map_5a86a823c94abc29f7af77eb55dccd12);
         
     


### PR DESCRIPTION
## Summary
- load the Leaflet.markercluster plugin and styles so markers can be clustered
- convert each era overlay feature group into a marker cluster group for clearer navigation

## Testing
- Manual verification via http://127.0.0.1:8000/index.html

------
https://chatgpt.com/codex/tasks/task_e_68e243620110832da11e7ef879c9febf