### PR TITLE
Add road names to satellite map by switching to hybrid view

### DIFF
--- a/index.html
+++ b/index.html
@@ -132,7 +132,7 @@
         
     
             var tile_layer_92045248e0b26d32f028b817d130809a = L.tileLayer(
-                "https://mt1.google.com/vt/lyrs=s\u0026x={x}\u0026y={y}\u0026z={z}",
+                "https://mt1.google.com/vt/lyrs=y\u0026x={x}\u0026y={y}\u0026z={z}",
                 {
   "minZoom": 0,
   "maxZoom": 22,


### PR DESCRIPTION
Changed Google Maps tile layer from satellite-only mode (lyrs=s) to hybrid mode (lyrs=y), which displays satellite imagery with road names and labels overlaid.